### PR TITLE
Recognize .babelrc as JSON5

### DIFF
--- a/grammars/json5.cson
+++ b/grammars/json5.cson
@@ -1,5 +1,6 @@
 'scopeName': 'source.json5'
 'fileTypes': [
+  '.babelrc'
   'json5'
 ]
 'name': 'JSON5'


### PR DESCRIPTION
`.babelrc`, the config file of Babel, should be recognized as JSON5.

https://babeljs.io/docs/usage/babelrc/